### PR TITLE
Implement PDF ingestion utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.egg-info/
+pytest_cache/
+data/raw/

--- a/src/ingest.py
+++ b/src/ingest.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import shutil
+import urllib.request
+
+from pypdf import PdfReader
+
+
+def download_ncert(url: str, dest_dir: Path) -> Path:
+    """Stream a PDF to data/raw/, skip if already exists, return file path."""
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    filename = url.split("/")[-1]
+    path = dest_dir / filename
+    if path.exists():
+        return path
+    with urllib.request.urlopen(url) as response, open(path, "wb") as f:
+        shutil.copyfileobj(response, f)
+    return path
+
+
+def extract_text(path: Path) -> list[str]:
+    """Return list of page-level strings using pypdf.PdfReader."""
+    reader = PdfReader(str(path))
+    pages = []
+    for page in reader.pages:
+        text = page.extract_text() or ""
+        pages.append(text)
+    return pages
+
+
+@dataclass
+class Chunk:
+    text: str
+    page: int
+    source: str  # file stem
+
+
+def chunk_pages(pages: list[str], max_chars: int = 1000) -> list[Chunk]:
+    """Split pages into overlapping chunks ≤ max_chars with ~200-char overlap."""
+    overlap = 200
+    chunks: list[Chunk] = []
+    for page_num, text in enumerate(pages, start=1):
+        start = 0
+        while start < len(text):
+            end = start + max_chars
+            chunk_text = text[start:end]
+            chunks.append(Chunk(text=chunk_text, page=page_num, source="document"))
+            if len(text) <= end:
+                break
+            start += max_chars - overlap
+    return chunks

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+import sys
+
+# Ensure src is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from ingest import download_ncert, extract_text, chunk_pages, Chunk
+
+
+SAMPLE_PDF = "https://raw.githubusercontent.com/mozilla/pdf.js/master/examples/learning/helloworld.pdf"
+
+
+def test_extract_and_chunk():
+    dest_dir = Path("data/raw")
+    pdf_path = download_ncert(SAMPLE_PDF, dest_dir)
+    assert pdf_path.exists()
+
+    pages = extract_text(pdf_path)
+    assert len(pages) > 0
+
+    chunks = chunk_pages(pages)
+    assert len(chunks) > 0
+    assert all(isinstance(c, Chunk) for c in chunks)
+    assert all(1 <= c.page <= len(pages) for c in chunks)


### PR DESCRIPTION
## Summary
- add a module `src/ingest.py` with helpers to download PDFs, extract pages, and chunk text
- create dataclass `Chunk`
- provide tests covering extraction and chunking
- ignore build artefacts and downloaded files in `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684473c0b460832fa76720f41ff9c8ce