### PR TITLE
Update README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,17 @@ flowchart TD
 
 ## How to run locally
 
-1. Install dependencies
+1. Install dependencies (requires **Streamlit ≥1.45**)
    ```bash
    pip install -e .
    ```
+   If you install packages manually, make sure your Streamlit version is at
+   least `1.45`:
+   ```bash
+   pip install "streamlit>=1.45"
+   ```
+   Older versions will raise a `TypeError` in `st.set_page_config` due to the
+   missing `theme` parameter.
 2. Place your PDFs in `data/raw/` and build the index
    ```bash
    python app/build_index.py data/raw/*.pdf


### PR DESCRIPTION
## Summary
- note that Streamlit >=1.45 is required
- show how to install the project or Streamlit explicitly
- warn that older Streamlit will raise a TypeError due to missing `theme` in `st.set_page_config`

## Testing
- `pre-commit run --files README.md`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68448272c244832faa283e0d93850171